### PR TITLE
RustInAction/第４章　ライフタイムと所有権と借用

### DIFF
--- a/Rust-in-Action/ch04/check-sats-1.rs
+++ b/Rust-in-Action/ch04/check-sats-1.rs
@@ -1,0 +1,26 @@
+#![allow(unused_variables)]
+
+#[derive(Debug)]
+enum StatusMessage {
+    Ok,
+}
+
+fn check_status(sta_id: u64) -> StatusMessage {
+    StatusMessage::Ok
+}
+
+fn main() {
+    let sat_a = 0;
+    let sat_b = 1;
+    let sat_c = 2;
+
+    let a_status = check_status(sat_a);
+    let b_status = check_status(sat_b);
+    let c_status = check_status(sat_c);
+    println!("a: {:?}, b: {:?}, c: {:?}", a_status, b_status, c_status);
+
+    let a_status = check_status(sat_a);
+    let b_status = check_status(sat_b);
+    let c_status = check_status(sat_c);
+    println!("a: {:?}, b: {:?}, c: {:?}", a_status, b_status, c_status);
+}

--- a/Rust-in-Action/ch04/check-sats-2.rs
+++ b/Rust-in-Action/ch04/check-sats-2.rs
@@ -1,0 +1,31 @@
+#![allow(unused_variables)]
+
+#[derive(Debug)]
+struct CubeSat {
+    id: u64,
+}
+
+#[derive(Debug)]
+enum StatusMessage {
+    Ok,
+}
+
+fn check_status(sta_id: CubeSat) -> StatusMessage {
+    StatusMessage::Ok
+}
+
+fn main() {
+    let sat_a = CubeSat { id: 0 };
+    let sat_b = CubeSat { id: 1 };
+    let sat_c = CubeSat { id: 2 };
+
+    let a_status = check_status(sat_a);
+    let b_status = check_status(sat_b);
+    let c_status = check_status(sat_c);
+    println!("a: {:?}, b: {:?}, c: {:?}", a_status, b_status, c_status);
+
+    let a_status = check_status(sat_a);
+    let b_status = check_status(sat_b);
+    let c_status = check_status(sat_c);
+    println!("a: {:?}, b: {:?}, c: {:?}", a_status, b_status, c_status);
+}

--- a/Rust-in-Action/ch04/check-sats-3.rs
+++ b/Rust-in-Action/ch04/check-sats-3.rs
@@ -1,0 +1,36 @@
+#![allow(unused_variables)]
+
+#[derive(Debug)]
+struct CubeSat {
+    id: u64,
+}
+
+#[derive(Debug)]
+enum StatusMessage {
+    Ok,
+}
+
+fn check_status(sat_id: CubeSat) -> CubeSat {
+    println!("{:?}: {:?}", sat_id, StatusMessage::Ok);
+    sat_id
+}
+
+fn print_id(sat_id: CubeSat) {
+    println!("{}", sat_id.id);
+}
+
+fn main() {
+    let sat_a = CubeSat { id: 0 };
+    let sat_b = CubeSat { id: 1 };
+    let sat_c = CubeSat { id: 2 };
+
+    let sat_a = check_status(sat_a);
+    let sat_b = check_status(sat_b);
+    let sat_c = check_status(sat_c);
+
+    let sat_a = check_status(sat_a);
+    let sat_b = check_status(sat_b);
+    let sat_c = check_status(sat_c);
+
+    print_id(sat_a);
+}

--- a/Rust-in-Action/ch04/check-sats-clone-and-copy-traits.rs
+++ b/Rust-in-Action/ch04/check-sats-clone-and-copy-traits.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, Clone, Copy)]
+struct CubeSat {
+    id: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StatusMessage {
+    Ok,
+}
+
+fn check_status(_sat_id: CubeSat) -> StatusMessage {
+    StatusMessage::Ok
+}
+
+fn main() {
+    let sat_a = CubeSat { id: 0 };
+
+    let a_status = check_status(sat_a);
+    println!("a: {:?}", a_status);
+    println!("{}", sat_a.id);
+
+    let a_status = check_status(sat_a.clone());
+    println!("a: {:?}", a_status.clone());
+}

--- a/Rust-in-Action/ch04/rc-groundstation.rs
+++ b/Rust-in-Action/ch04/rc-groundstation.rs
@@ -1,0 +1,10 @@
+use std::rc::Rc;
+
+#[derive(Debug)]
+struct GroundStation {}
+
+fn main() {
+    let base = Rc::new(GroundStation {});
+
+    println!("{:?}", base);
+}

--- a/Rust-in-Action/ch04/rc-refcell-groundstation.rs
+++ b/Rust-in-Action/ch04/rc-refcell-groundstation.rs
@@ -1,0 +1,37 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug)]
+struct GroundStation {
+    radio_freq: f64,
+}
+
+fn main() {
+    let base: Rc<RefCell<GroundStation>> =
+        Rc::new(RefCell::new(GroundStation { radio_freq: 87.65 }));
+    println!("base: {:?}", base);
+
+    // 新しいスコープを導入。その中ではbaseの可変借用が許される
+    {
+        let mut base_2 = base.borrow_mut();
+        base_2.radio_freq -= 12.34;
+        println!("base_2: {:?}", base_2);
+    }
+
+    println!("base: {:?}", base);
+
+    let mut base_3 = base.borrow_mut();
+    base_3.radio_freq += 43.21;
+
+    println!("base: {:?}", base);
+    println!("base_3: {:?}", base_3);
+}
+
+/* Note
+- 他の型でラッピングすることで、型に機能を盛り込むと、実行時の性能が落ちる
+-　Cloneの実装に許容できないほどコストがかかる場合は、Rc<T>が手軽な代案かもしれない。これによって、２つの場所から所有権を共有できるようになる。
+
+- Rc<T>は「スレッド安全」ではない。
+マルチスレッドのコードでは、Rc<T>の代わりにArc<T>を、Rc<RefCell<T>>の代わりにArc<Mutex<T>>を使う方が、ずっと優れている。
+Arcは、Atomic reference counterの略
+ */

--- a/Rust-in-Action/ch04/sat-mailbox.rs
+++ b/Rust-in-Action/ch04/sat-mailbox.rs
@@ -1,0 +1,46 @@
+#[derive(Debug)]
+struct CubeSat {
+    id: u64,
+    mailbox: Mailbox,
+}
+
+#[derive(Debug)]
+struct Mailbox {
+    messages: Vec<Message>,
+}
+
+type Message = String;
+
+struct GroundStation;
+
+impl GroundStation {
+    fn send(&self, to: &mut CubeSat, msg: Message) {
+        to.mailbox.messages.push(msg);
+    }
+}
+
+impl CubeSat {
+    fn recv(&mut self) -> Option<Message> {
+        self.mailbox.messages.pop()
+    }
+}
+
+fn main() {
+    let base = GroundStation {};
+    let mut sat_a = CubeSat {
+        id: 0,
+        mailbox: Mailbox { messages: vec![] },
+    };
+
+    println!("t0: {:?}", sat_a);
+
+    base.send(&mut sat_a, Message::from("hello there!")); // <1>
+
+    println!("t1: {:?}", sat_a);
+
+    let msg = sat_a.recv();
+    println!("t2: {:?}", sat_a);
+
+    println!("msg: {:?}", msg);
+    println!("{}", sat_a.id);
+}

--- a/Rust-in-Action/ch04/short-lived-strategy.rs
+++ b/Rust-in-Action/ch04/short-lived-strategy.rs
@@ -1,0 +1,83 @@
+#![allow(unused_variables)]
+
+#[derive(Debug)]
+struct CubeSat {
+    id: u64,
+}
+
+#[derive(Debug)]
+struct Mailbox {
+    messages: Vec<Message>,
+}
+
+#[derive(Debug)]
+struct Message {
+    to: u64,
+    content: String,
+}
+
+struct GroundStation {}
+
+impl Mailbox {
+    fn post(&mut self, msg: Message) {
+        self.messages.push(msg)
+    }
+
+    fn deliver(&mut self, recipient: &CubeSat) -> Option<Message> {
+        for i in 0..self.messages.len() {
+            if self.messages[i].to == recipient.id {
+                let msg = self.messages.remove(i);
+                return Some(msg);
+            }
+        }
+
+        None
+    }
+}
+
+impl GroundStation {
+    fn connect(&self, sat_id: u64) -> CubeSat {
+        CubeSat { id: sat_id }
+    }
+
+    fn send(&self, mailbox: &mut Mailbox, msg: Message) {
+        mailbox.post(msg);
+    }
+}
+
+impl CubeSat {
+    fn recv(&self, mailbox: &mut Mailbox) -> Option<Message> {
+        mailbox.deliver(&self)
+    }
+}
+
+fn fetch_sat_ids() -> Vec<u64> {
+    vec![1, 2, 3]
+}
+
+fn main() {
+    let mut mail = Mailbox { messages: vec![] };
+
+    let base = GroundStation {};
+
+    let sat_ids = fetch_sat_ids();
+
+    for sat_id in sat_ids {
+        let sat = base.connect(sat_id);
+        let msg = Message {
+            to: sat_id,
+            content: String::from("hello"),
+        };
+        base.send(&mut mail, msg);
+    }
+
+    let sat_ids = fetch_sat_ids();
+
+    for sat_id in sat_ids {
+        let sat = base.connect(sat_id);
+
+        let msg = sat.recv(&mut mail);
+        println!("{:?}: {:?}", sat, msg);
+        println!("{:?}", msg.unwrap().content);
+    }
+}


### PR DESCRIPTION
- feat(rust in action/p.126~127): 4-1: CubeSat群の、整数をベースとする状態をチェックする
- feat(rust in action/p.134~136): 4.4 所有権はどのように移動するのか
- feat(rust in action/p.139~142): 4.5.1 完全な所有権を必要としない場合は参照を使う
- feat(rust in action/p.142~148): 4.5.2 長生きする値を少なくする
- feat(rust in action/p.148~151): 4.5.3 値を複製
- feat(rust in action/p.151~155): 4.5.4 データを専用の型でラップする
